### PR TITLE
Avoid creating new component every render

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "version": "standard-version",
     "reset": "git clean -dfx && git reset --hard && npm i",
     "all": "run-s reset test cov:check doc:html",
-    "prepare-release": "run-s all version doc:publish",
+    "manual-release": "run-s all version doc:publish",
     "size": "size-limit",
     "storybook:start": "bluebase storybook:start",
     "storybook-native": "bluebase storybook-native:start",

--- a/src/getComponent.tsx
+++ b/src/getComponent.tsx
@@ -14,19 +14,28 @@ export function getComponent<T = any>(...keys: string[]) {
 		throw Error('getComponent method needs at least one key');
 	}
 
+	let Component: React.ComponentType<any>;
 	const displayName = keys.join('_');
 
 	const BlueBaseComponent = (props: T) => (
 		<BlueBaseConsumer>
 			{(BB: BlueBase) => {
 
+				// If there is no BlueBase context, throw an Error
 				if (!BB) {
-				// tslint:disable-next-line: max-line-length
+					// tslint:disable-next-line: max-line-length
 					throw Error(`Could not resolve component "${displayName}" in "getComponent" command. Reason: BlueBase context not found.`);
 				}
 
-				const Component = BB.Components.resolve(...keys);
+				// We don't want to resolve the component on every render.
+				// If we don't do this, a new component is created on every
+				// render, causing various set of problems.
+				if (!Component) {
+					// Do the rain dance
+					Component = BB.Components.resolve(...keys);
+				}
 
+				// Render
 				return React.createElement(Component, props);
 			}}
 		</BlueBaseConsumer>


### PR DESCRIPTION
Resolving component during each render causes a new component generation. Apart from performance issues, this messes up animations, forms, etc. This commit modifies the `getComponent` function so that it caches the resolved component the first time. Whenever it is requested again, the cached component is used rather than resolving a new one again.