### PR TITLE
feat: value renamed to checked on selection controls

### DIFF
--- a/src/components/Checkbox.ts
+++ b/src/components/Checkbox.ts
@@ -64,7 +64,4 @@ export const CheckboxDefaultProps = {
 	color: 'secondary',
 	disabled: false,
 	labelPlacement: 'end',
-	onValueChange: () => {
-		return;
-	},
 };

--- a/src/components/Checkbox.ts
+++ b/src/components/Checkbox.ts
@@ -3,6 +3,11 @@ import { getComponent } from '../getComponent';
 
 export interface CheckboxProps extends ViewProps {
 	/**
+	 * If true, the component is checked.
+	 */
+	checked?: boolean;
+
+	/**
 	 * Color of the Checkbox.
 	 */
 	color?: 'primary' | 'secondary' | 'default' | string;
@@ -24,10 +29,9 @@ export interface CheckboxProps extends ViewProps {
 	testID?: string;
 
 	/**
-	 * The value of the Checkbox. If true the Checkbox will be turned on.
-	 * Default value is false.
+	 * The value of the component.
 	 */
-	value?: boolean;
+	value?: string | number | boolean;
 
 	/**
 	 * The text to be used in an enclosing label element.
@@ -51,6 +55,7 @@ export const Checkbox = getComponent<CheckboxProps>('Checkbox');
  * Default props for Checkbox component
  */
 export const CheckboxDefaultProps = {
+	checked: false,
 	color: 'secondary',
 	disabled: false,
 	labelPlacement: 'end',

--- a/src/components/Checkbox.ts
+++ b/src/components/Checkbox.ts
@@ -19,9 +19,14 @@ export interface CheckboxProps extends ViewProps {
 	disabled?: boolean;
 
 	/**
+	 * Similar to `onValueChange`, but passes `checked` prop instead of `value`.
+	 */
+	onChange?: (checked: boolean) => void;
+
+	/**
 	 * Invoked with the new value when the value changes.
 	 */
-	onValueChange?: (value: boolean) => void;
+	onValueChange?: (value: string | number | boolean) => void;
 
 	/**
 	 * Used to locate this view in end-to-end tests.

--- a/src/components/Radio.ts
+++ b/src/components/Radio.ts
@@ -3,6 +3,11 @@ import { getComponent } from '../getComponent';
 
 export interface RadioProps extends ViewProps {
 	/**
+	 * If true, the component is checked.
+	 */
+	checked?: boolean;
+
+	/**
 	 * Color of the Radio.
 	 */
 	color?: 'primary' | 'secondary' | 'default' | string;
@@ -24,10 +29,9 @@ export interface RadioProps extends ViewProps {
 	testID?: string;
 
 	/**
-	 * The value of the Radio. If true the Radio will be turned on.
-	 * Default value is false.
+	 * The value of the component.
 	 */
-	value?: boolean;
+	value?: string | number | boolean;
 
 	/**
 	 * The text to be used in an enclosing label element.
@@ -46,6 +50,7 @@ export const Radio = getComponent<RadioProps>('Radio');
  * Default props for Radio component
  */
 export const RadioDefaultProps = {
+	checked: false,
 	color: 'secondary',
 	disabled: false,
 	labelPlacement: 'end',

--- a/src/components/Radio.ts
+++ b/src/components/Radio.ts
@@ -59,7 +59,4 @@ export const RadioDefaultProps = {
 	color: 'secondary',
 	disabled: false,
 	labelPlacement: 'end',
-	onValueChange: () => {
-		return;
-	},
 };

--- a/src/components/Radio.ts
+++ b/src/components/Radio.ts
@@ -19,9 +19,14 @@ export interface RadioProps extends ViewProps {
 	disabled?: boolean;
 
 	/**
+	 * Similar to `onValueChange`, but passes `checked` prop instead of `value`.
+	 */
+	onChange?: (checked: boolean) => void;
+
+	/**
 	 * Invoked with the new value when the value changes.
 	 */
-	onValueChange?: (value: boolean) => void;
+	onValueChange?: (value: string | number | boolean) => void;
 
 	/**
 	 * Used to locate this view in end-to-end tests.

--- a/src/components/RadioGroup.ts
+++ b/src/components/RadioGroup.ts
@@ -10,7 +10,7 @@ export interface RadioGroupProps extends ViewProps {
 	/**
 	 * Value of the currently selected radio button.
 	 */
-	value: string;
+	value: string | number | boolean;
 
 	/**
 	 * React elements containing radio buttons.

--- a/src/components/RadioGroup.ts
+++ b/src/components/RadioGroup.ts
@@ -5,7 +5,7 @@ export interface RadioGroupProps extends ViewProps {
 	/**
 	 * Function to execute on selection change.
 	 */
-	onValueChange: (value: string) => any;
+	onValueChange: (value: string | number | boolean) => any;
 
 	/**
 	 * Value of the currently selected radio button.

--- a/src/components/Switch.ts
+++ b/src/components/Switch.ts
@@ -49,7 +49,4 @@ export const SwitchDefaultProps = {
 	color: 'secondary',
 	disabled: false,
 	labelPlacement: 'start',
-	onValueChange: () => {
-		return;
-	},
 };

--- a/src/components/Switch.ts
+++ b/src/components/Switch.ts
@@ -1,7 +1,13 @@
+import { Omit } from '@bluebase/core';
 import { SwitchProps as NativeSwitchProps } from 'react-native';
 import { getComponent } from '../getComponent';
 
-export interface SwitchProps extends NativeSwitchProps {
+export interface SwitchProps extends Omit<NativeSwitchProps, 'value'> {
+	/**
+	 * If true, the component is checked.
+	 */
+	checked?: boolean;
+
 	/**
 	 * Color of the switch.
 	 */
@@ -16,6 +22,11 @@ export interface SwitchProps extends NativeSwitchProps {
 	 * The position of the label.
 	 */
 	labelPlacement?: 'end' | 'start' | 'top' | 'bottom';
+
+	/**
+	 * The value of the component.
+	 */
+	value?: string | number | boolean;
 }
 
 export const Switch = getComponent<SwitchProps>('Switch');
@@ -24,6 +35,7 @@ export const Switch = getComponent<SwitchProps>('Switch');
  * Default props for Switch component
  */
 export const SwitchDefaultProps = {
+	checked: false,
 	color: 'secondary',
 	disabled: false,
 	labelPlacement: 'start',

--- a/src/components/Switch.ts
+++ b/src/components/Switch.ts
@@ -2,7 +2,7 @@ import { Omit } from '@bluebase/core';
 import { SwitchProps as NativeSwitchProps } from 'react-native';
 import { getComponent } from '../getComponent';
 
-export interface SwitchProps extends Omit<NativeSwitchProps, 'value'> {
+export interface SwitchProps extends Omit<NativeSwitchProps, 'value' | 'onValueChange'> {
 	/**
 	 * If true, the component is checked.
 	 */
@@ -27,6 +27,16 @@ export interface SwitchProps extends Omit<NativeSwitchProps, 'value'> {
 	 * The value of the component.
 	 */
 	value?: string | number | boolean;
+
+	/**
+	 * Similar to `onValueChange`, but passes `checked` prop instead of `value`.
+	 */
+	onChange?: (checked: boolean) => void;
+
+	/**
+	 * Invoked with the new value when the value changes.
+	 */
+	onValueChange?: (value: string | number | boolean) => void;
 }
 
 export const Switch = getComponent<SwitchProps>('Switch');


### PR DESCRIPTION
On "Checkbox", "Radio" and "Switch" components, value is renamed to
"checked", and value field is now used to store any value related to the
field. This behavior is similar to HTML and will satisfy use cases like
radio groups.

BREAKING CHANGE: `value` prop in all existing implementations will have to be renamed to "checked".